### PR TITLE
refactor: take screenshot on test failure [#23]

### DIFF
--- a/src/lib/helper.js
+++ b/src/lib/helper.js
@@ -1,3 +1,5 @@
+const { v4: uniqueId } = require('uuid');
+
 module.exports = helper = {
     clickAndWaitForNavigation :async (page, id)=>{
         await Promise.all([
@@ -11,5 +13,9 @@ module.exports = helper = {
     checkIfTextExist : async (page, text)=>{
         let textArr = await page.$x(`(//*[text()="${text}"])`) 
         return textArr.length > 0
-    }
+    },
+    takeScreenShot: async (page)=>{
+        let name = uniqueId()
+        await page.screenshot({ path: `reports/screenshots/${name}.png` });
+     }
 }

--- a/src/tests/TestBase.js
+++ b/src/tests/TestBase.js
@@ -1,5 +1,4 @@
 const puppeteer = require('puppeteer');
-const { v4: uniqueId } = require('uuid');
 
 module.exports = class TestBase {
   constructor(){
@@ -12,9 +11,4 @@ module.exports = class TestBase {
   async cleanup(){
     await this.browser.close();
   }
-
-  async takeScreenShot(page){
-    let name = uniqueId()
-    await page.screenshot({ path: `reports/screenshots/${name}.png` });
- }
 }

--- a/src/tests/amazon/step_definition/login_page_implementation.js
+++ b/src/tests/amazon/step_definition/login_page_implementation.js
@@ -23,6 +23,11 @@ step("Enter username <user>", async function(user) {
 });
 
 step("Check if username <user> is visible", async function(user) {
-	assert.ok(await helper.checkIfTextExist(amazonLogin.page,user))
+    try {
+        assert.ok(await helper.checkIfTextExist(amazonLogin.page,user))       
+    } catch (error) {
+        if(e instanceof AssertionError)
+            await helper.takeScreenShot(amazonLogin.page)
+    }
 });
 


### PR DESCRIPTION
@h2grover Currently I handled test failure in one implementation to verify if the approach is correct. 
Also, when I applied try/catch to handle assertion error, the output showed that test is passed although it did take screenshot when error is caught.